### PR TITLE
Specify user home directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Monitor a user's `Downloads` folder for VPN config files and automatically use t
 There is an installation script `install.sh` provided which should work for Ubuntu (and derivatives), and will hopefully give any other curious folk an idea of the manual steps required.
 To run the installation script enter the following into a terminal:
 ```bash
-curl -s 'https://raw.githubusercontent.com/RobinKnipe/autovpn/master/install.sh' | sudo bash -s
+curl -s 'https://raw.githubusercontent.com/RobinKnipe/autovpn/master/install.sh' | sudo bash -s $HOME
 ```
 You can check everything worked with `sudo systemctl list-dependencies` - you should see something like the following example - note the `autovpn.service` unit is listed as the second item under the `default.target` (the dot next to it should _hopefully_ be green):
 ```bash

--- a/autovpn
+++ b/autovpn
@@ -9,7 +9,7 @@ default_filename_pattern='^.+\.ovpn$'
 filename_pattern=${file_name_pattern:-$default_filename_pattern}
 default_exclude_files=".*\.crdownload|\.org\.chromium\.Chromium\..*"
 exclude_files="${exclude_files:-$default_exclude_files}"
-default_download_dir="${HOME}/Downloads"
+default_download_dir="${USER_HOME}/Downloads"
 download_dir="${download_dir:-$default_download_dir}"
 
 # Watch the Downloads directory for new VPN config files

--- a/autovpn.service
+++ b/autovpn.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Automatically connect to VPN after config download
-#Documentation=Documentation needed!
+Documentation=https://github.com/RobinKnipe/autovpn
 After=network-online.service
 
 [Service]

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,12 @@ if [ `whoami` != "root" ] ; then
   exit 1
 fi
 
+# check the user home dir is specified
+if [ ! -d "$1" ] ; then
+  echo "ERROR: the script must be called with one parameter, the location of the user's home directory"
+  exit 2
+fi
+
 # Install autovpn
 
 user_dir="$1"
@@ -22,6 +28,15 @@ function install_prerequisits {
   fi
 }
 
+# setup the properties file
+function install_properties {
+  mkdir -p "${user_dir}/.config"
+  props="${user_dir}/.config/autovpn.properties"
+  echo "# the location of the user's downloads folder monitored by autovpn" > ${props}
+  echo "download_dir=${user_dir}/Downloads" >> ${props}
+  chown `ls -ld ${user_dir}/ | awk '{print $3":"$4}'` "${user_dir}/.config" "${props}"
+}
+
 # download the main autovpn script file
 function install_main_script {
   echo 'Installing the main autovpn script file'
@@ -31,9 +46,20 @@ function install_main_script {
 }
 
 # download and activate the autovpn systemd unit
-function install_unit_file {
+function install_unit_files {
+  # stop the service if it is already installed
+  if [ -f "${unit_dir}/autovpn.service" ] ; then
+    systemctl stop autovpn.service
+    systemctl disable autovpn.service
+    systemctl daemon-reload
+  fi
+
   echo 'Installing the autovpn systemd unit file'
-  mkdir -p ${unit_dir}
+  mkdir -p "${unit_dir}/autovpn.service.d"
+  unit_env="${unit_dir}/autovpn.service.d/env.conf"
+  echo "[Service]" > ${unit_env}
+  echo "Environment=\"USER_HOME=${user_dir}\"" >> ${unit_env}
+
   curl -so "${unit_dir}/autovpn.service" "${repo}/autovpn.service"
   systemctl daemon-reload
   systemctl start autovpn.service
@@ -41,5 +67,6 @@ function install_unit_file {
 }
 
 install_prerequisits
+install_properties
 install_main_script
-install_unit_file
+install_unit_files


### PR DESCRIPTION
Call the `install.sh` script with `$HOME`, so autovpn knows where to look for properties and downloads.