### PR TITLE
Only close similar old connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ exclude_files=".*\.part"
 ### Auto-remove used VPN config files
 By default the service will remove the VPN configuration files after it tries to connect, so that the downloads directory does not get unnecessarily cluttered. To disable this behaviour, set the `auto_remove` option to `no` or `false`.
 
+### Auto close old VPN connections
+If the properties file contains a value for property `close_filename_pattern`, this regex will be used to find old VPN connections and close them. This is useful in cases where VPN configuration files have to be downloaded regularly (e.g. for short-lived connections), often the configuration filename will contain the date and/or time.
+
+For example - if we consider the following three configuration filenames:
+```
+vpn-my-con-1324.ovpn
+vpn-site-con-1203.ovpn
+vpn-other-con-2155.ovpn
+```
+Each filename contains the name of the connection followed by the time it was downloaded. Assuming connections have already been automatically started for each file, when another configuration file is downloaded named `vpn-my-con-1430.ovpn`, the following property entry would close the existing connection from the file `vpn-my-con-1324.ovpn`:
+```properties
+close_filename_pattern="vpn-(\w+-)"
+```
+Similarly if new configurations where downloaded for the other connections, the old connection would be closed before starting the new one. The regex matches a part of the downloaded filename and it is this match that is used to find old connections - in the above example the regex would match "`vpn-my-con-`" from `vpn-my-con-1430.ovpn`, and then use that to find the connection opened for file `vpn-my-con-1324.ovpn`.
+
 ### Important note
 Simply making changes to the properties file will not take effect until the service restarts - this happens when the OS boots, or can be manualy triggered by running:
 ```bash

--- a/autovpn
+++ b/autovpn
@@ -5,8 +5,8 @@ if [ -f "${props_file}" ] ; then
   source ${props_file}
 fi
 # replace empty values with defaults
-default_filename_pattern='^.+\.ovpn$'
-filename_pattern=${file_name_pattern:-$default_filename_pattern}
+default_open_filename_pattern='^.+\.ovpn$'
+open_filename_pattern=${file_name_pattern:-$default_filename_pattern}
 default_exclude_files=".*\.crdownload|\.org\.chromium\.Chromium\..*"
 exclude_files="${exclude_files:-$default_exclude_files}"
 default_download_dir="${USER_HOME}/Downloads"
@@ -23,11 +23,14 @@ inotifywait -mqe create --exclude "${exclude_files}" "${default_download_dir}" |
       vpn=`echo ${file} | awk -F '-' '{print $2}'`
 
       # Check if an old connection already exists
-      cons=`ps -ef|grep "openvpn.*vpn-${vpn}-.*.ovpn"|grep -v grep|awk '{print $2}'`
-      if [ -n "${cons}" ]
-      then
-        echo "Removing old '${vpn}' VPN connection..."
-        kill ${cons}
+      if [ -n "${close_filename_pattern}" ] ; then
+        close_file_match=`grep -Eo "${close_filename_pattern}"`
+        cons=`pgrep --list-full openvpn | grep "${close_file_match}" | awk '{print $2}'`
+        if [ -n "${cons}" ]
+        then
+          echo "Removing old '${close_file_match}' VPN connection..."
+          kill ${cons}
+        fi
       fi
 
       # Connect to the VPN

--- a/install.sh
+++ b/install.sh
@@ -30,11 +30,14 @@ function install_prerequisits {
 
 # setup the properties file
 function install_properties {
-  mkdir -p "${user_dir}/.config"
   props="${user_dir}/.config/autovpn.properties"
-  echo "# the location of the user's downloads folder monitored by autovpn" > ${props}
-  echo "download_dir=${user_dir}/Downloads" >> ${props}
-  chown `ls -ld ${user_dir}/ | awk '{print $3":"$4}'` "${user_dir}/.config" "${props}"
+  # ...unless it already exists
+  if [ ! -e "${props}" ] ; then
+    mkdir -p "${user_dir}/.config"
+    echo "# the location of the user's downloads folder monitored by autovpn" > ${props}
+    echo "download_dir=${user_dir}/Downloads" >> ${props}
+    chown `ls -ld ${user_dir}/ | awk '{print $3":"$4}'` "${user_dir}/.config" "${props}"
+  fi
 }
 
 # download the main autovpn script file


### PR DESCRIPTION
This feature is now controlled by a property: `close_filename_pattern`. This regex definition matches against the downloaded file that triggered `autovpn`, and that match is used to find any similar old connection(s) which should be close.

If omitted from the properties file the feature is disabled.