### PR TITLE
Only close same old connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ default.target
 ```
 
 ## Configuration
-When the service starts, it looks for a file `~/.config/autovpn.properties`. This file contains a few options to tailor the script:
+When the service starts, it looks for a file `${HOME}/.config/autovpn.properties`. This file contains a few options to tailor the script:
 
 ### Download folder location
 By default the monitored folder is: `"${HOME}/Downloads"`. To change it, add the `download_dir` property, as in the following example:
@@ -35,6 +35,22 @@ By default any downloaded VPN file matching the general filename patter `*.ovpn`
 filename_pattern='^(my-connection|some-other).ovpn$'
 ```
 NOTE: The single quotes (') around the regex in the pattern are important.
+
+### Auto close old VPN connections
+Before starting a new connection, the service will try to close any existing VPN connection that was started with a configuration file with the same name. Often configuration files are only valid for a limited time, and a timestamp forms part of the filename - in these cases the `vpn_name_suffix` property can be set to indicate the filename ending, as in the following examples:
+```properties
+# the current date suffix, e.g. my-connection-20190212.ovpn
+vpn_name_suffix='-[0-9]{8}.ovpn'
+# the current date and time suffix, e.g. my-connection-20190212-1354.ovpn
+vpn_name_suffix='-[0-9]{8}-[0-9]{4}.ovpn'
+```
+It may also be useful to reuse this suffix as part of the `filename_pattern` property, as in this example:
+```properties
+# current date, time, and count (for duplicate names), e.g. "con-20190212-1354 (2).ovpn"
+vpn_name_suffix='-[0-9]{8}-[0-9]{4}( \([0-9]+\))?\.ovpn'
+# matches names starting with "vpn", then dash separated words, ending with above suffix
+filename_pattern="^vpn(-\w+)*${vpn_name_suffix}$"
+```
 
 ### Download files to ignore pattern
 By default Chromium's temporary files will be ignored (regex: `.*\.crdownload|\.org\.chromium\.Chromium\..*`). To change this add the `exclude_files` property, as in the following example:

--- a/autovpn
+++ b/autovpn
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # check for properties file
-if [ -f "${props_file}" ] ; then
-  source ${props_file}
+if [ -f "${PROPS_FILE}" ] ; then
+  source ${PROPS_FILE}
 fi
 # replace empty values with defaults
 default_filename_pattern='^.+\.ovpn$'
@@ -20,23 +20,27 @@ inotifywait -mqe create --exclude "${exclude_files}" "${default_download_dir}" |
     if [ "${event}" = "CREATE" ] && [[ "${file}" =~ ${filename_pattern} ]]
     then
       # Get the VPN name
-      vpn=`echo ${file} | awk -F '-' '{print $2}'`
+      if [ -n "${vpn_name_suffix}" ] ; then
+        vpn=`echo ${file} | sed -E "s/${vpn_name_suffix}//"`
+      fi
+      vpn=${vpn:-$file}
 
       # Check if an old connection already exists
-      cons=`ps -ef|grep "openvpn.*vpn-${vpn}-.*.ovpn"|grep -v grep|awk '{print $2}'`
+      cons=`pgrep --list-full openvpn | grep "${vpn}" | awk '{print $1}'`
       if [ -n "${cons}" ]
       then
-        echo "Removing old '${vpn}' VPN connection..."
+        echo "Closing old connection: '${vpn}'..."
         kill ${cons}
       fi
 
       # Connect to the VPN
-      echo "Connecting to the '${vpn}' VPN..."
+      echo "Connecting to: '${vpn}'..."
       openvpn --config "${path}${file}" &
 
       # Wait a mo then remove the VPN config file
       if [ "${auto_remove}" != "no" ] || [ "${auto_remove}" != "false" ] ; then
         sleep 2
+        echo "Removing old configuration file: ${file}"
         rm "${path}${file}"
       fi
     fi

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ fi
 # Install autovpn
 
 user_dir="$1"
+props="${user_dir}/.config/autovpn.properties"
 repo="https://raw.githubusercontent.com/RobinKnipe/autovpn/master/"
 script_dir=/usr/share/autovpn
 unit_dir=/etc/systemd/system
@@ -30,7 +31,6 @@ function install_prerequisits {
 
 # setup the properties file
 function install_properties {
-  props="${user_dir}/.config/autovpn.properties"
   # ...unless it already exists
   if [ ! -e "${props}" ] ; then
     mkdir -p "${user_dir}/.config"
@@ -62,6 +62,7 @@ function install_unit_files {
   unit_env="${unit_dir}/autovpn.service.d/env.conf"
   echo "[Service]" > ${unit_env}
   echo "Environment=\"USER_HOME=${user_dir}\"" >> ${unit_env}
+  echo "Environment=\"PROPS_FILE=${props}\"" >> ${unit_env}
 
   curl -so "${unit_dir}/autovpn.service" "${repo}/autovpn.service"
   systemctl daemon-reload


### PR DESCRIPTION
Improves and simplifies the check to match the current configuration filename with any previously started VPN connections.